### PR TITLE
Fix for the `Invalid Exclude` warnings in Xcode 13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ playground.xcworkspace
 # Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
 # Packages/
 .build/
+.swiftpm
 
 # CocoaPods
 #

--- a/Package.swift
+++ b/Package.swift
@@ -32,8 +32,7 @@ let package = Package(
     ],
     targets: [
         .target(
-            name: "Signals",
-            exclude: ["Info.plist"]
+            name: "Signals"
         ),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
     targets: [
         .target(
             name: "Signals",
-            exclude: ["Signals.xcodeproj", "README.md", "Sources/Info.plist", "Sources/Signals.h", "Tests"]
+            exclude: ["Info.plist"]
         ),
     ]
 )


### PR DESCRIPTION
Fix for the `Invalid Exclude` warnings in Xcode 13

## Description
I removed the invalid exclusions and updated the .gitignore file as seen on other IBM-Swift projects after the update to Xcode 13.

## How Has This Been Tested?
Tested on my project using the forked repo. Warnings resolved and package working as expected.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.

I'm part of IBM org so I don't know if I need to submit a CLA form.
Close #26